### PR TITLE
Update to 12.1.260.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM ubuntu:24.04 AS eset-builder
 
 # Add installer
 # ESET versions
-ARG ESET_VERSION=12.1.252.0
+ARG ESET_VERSION=12.1.260.0
 
 ADD https://repository.eset.com/v1/com/eset/apps/business/era/server/linux/v12/${ESET_VERSION}/server_linux_x86_64.sh /install/server-linux-x86_64.sh
 RUN sed -i 's|config_ProgramConfigDir=.*|config_ProgramConfigDir=/config|g' /install/server-linux-x86_64.sh \


### PR DESCRIPTION
- Updated to the newest version
- Updated CI Action

Would it be possible to close the old PR's from dependabot, as they are not active anymore?
